### PR TITLE
Add accessibility to icon button

### DIFF
--- a/App.js
+++ b/App.js
@@ -64,10 +64,14 @@ const TabNavigator = () => (
       tabBarShowLabel: false,
       headerShown: false,
     }}
+    accessibilityRole="menu"
   >
     <Tab.Screen
       name={"Home"}
       component={Home}
+      accessible={true}
+      accessibilityLabel="Accueil"
+      accessibilityRole="menuitem"
       listeners={() => ({
         tabPress: () => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -82,6 +86,9 @@ const TabNavigator = () => (
     <Tab.Screen
       name={"Resultats"}
       component={Results}
+      accessible={true}
+      accessibilityLabel="Résultas"
+      accessibilityRole="menuitem"
       listeners={() => ({
         tabPress: () => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -96,6 +103,9 @@ const TabNavigator = () => (
     <Tab.Screen
       name={"Propositions"}
       component={Propositions}
+      accessible={true}
+      accessibilityLabel="Propositions"
+      accessibilityRole="menuitem"
       listeners={() => ({
         tabPress: () => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);

--- a/App.js
+++ b/App.js
@@ -87,7 +87,7 @@ const TabNavigator = () => (
       name={"Resultats"}
       component={Results}
       accessible={true}
-      accessibilityLabel="Résultas"
+      accessibilityLabel="Résultats"
       accessibilityRole="menuitem"
       listeners={() => ({
         tabPress: () => {

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -728,7 +728,7 @@ export default function Levels() {
                     animateCardOpacity
                     backgroundColor={"transparent"}
                     accessible={true}
-                    accessibilityHint="Swipez vers la gauche si vous êtes contre, vers la droite si vous êtes pour, et vers le bas si vous ne vous prenoncez pas"
+                    accessibilityHint="Swipez vers la gauche si vous êtes contre, vers la droite si vous êtes pour, et vers le bas si vous ne vous prononcez pas"
                     overlayLabels={{
                       left: {
                         title: "CONTRE",
@@ -810,7 +810,7 @@ export default function Levels() {
                       swipeRef.current.swipeBottom();
                     }}
                     accessible={true}
-                    accessibleLabel="Je ne me prenonce pas"
+                    accessibleLabel="Je ne me prononce pas"
                     accessibleRole="button"
                   >
                     <Text

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -582,6 +582,9 @@ export default function Levels() {
               {/* Bouton réglage */}
               <TouchableOpacity
                 onPress={() => navigation.navigate("Settings")}
+                accessible={true}
+                accessibilityLabel="Paramètres"
+                accessibilityRole="button"
                 style={{
                   position: "absolute",
                   top: -10,
@@ -724,6 +727,8 @@ export default function Levels() {
                     animateOverlayLabelsOpacity
                     animateCardOpacity
                     backgroundColor={"transparent"}
+                    accessible={true}
+                    accessibilityHint="Swipez vers la gauche si vous êtes contre, vers la droite si vous êtes pour, et vers le bas si vous ne vous prenoncez pas"
                     overlayLabels={{
                       left: {
                         title: "CONTRE",
@@ -788,6 +793,9 @@ export default function Levels() {
                     onPress={() => {
                       swipeRef.current.swipeLeft();
                     }}
+                    accessible={true}
+                    accessibleLabel="Contre"
+                    accessibleRole="button"
                   >
                     <FontAwesome
                       name={"times"}
@@ -801,6 +809,9 @@ export default function Levels() {
                     onPress={() => {
                       swipeRef.current.swipeBottom();
                     }}
+                    accessible={true}
+                    accessibleLabel="Je ne me prenonce pas"
+                    accessibleRole="button"
                   >
                     <Text
                       style={{
@@ -816,6 +827,9 @@ export default function Levels() {
                     onPress={() => {
                       swipeRef.current.swipeRight();
                     }}
+                    accessible={true}
+                    accessibleLabel="Pour"
+                    accessibleRole="button"
                   >
                     <FontAwesome
                       name={"heart"}


### PR DESCRIPTION
Les mal voyants qui utilisent des screens reader ont besoin d'avoir plus d'information sur les boutons contenant simplement des icon pour mieux comprendre l'écran. Idem pour l'espace swipable.